### PR TITLE
Add sentiment analysis web app

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,240 @@
+const reviewTextElement = document.getElementById('review-text');
+const sentimentIconElement = document.getElementById('sentiment-icon');
+const sentimentLabelElement = document.getElementById('sentiment-label');
+const scoreDetailsElement = document.getElementById('score-details');
+const analyzeButton = document.getElementById('analyze-button');
+const tokenInput = document.getElementById('token-input');
+const statusMessageElement = document.getElementById('status-message');
+const reviewCountElement = document.getElementById('review-count');
+
+let reviewTexts = [];
+let isAnalyzing = false;
+
+function setStatus(message) {
+    statusMessageElement.textContent = message;
+}
+
+function setReviewCount(count) {
+    if (typeof count === 'number' && count > 0) {
+        reviewCountElement.textContent = `${count.toLocaleString()} review${count === 1 ? '' : 's'} available.`;
+    } else {
+        reviewCountElement.textContent = '';
+    }
+}
+
+function updateSentimentDisplay({ iconClasses, toneClass, labelText, details }) {
+    const classList = ['sentiment-icon'];
+    if (toneClass) {
+        classList.push(toneClass);
+    }
+    const icons = Array.isArray(iconClasses) ? iconClasses : ['fa-solid', 'fa-circle-question'];
+    classList.push(...icons);
+    sentimentIconElement.className = classList.join(' ');
+    sentimentLabelElement.textContent = labelText;
+
+    scoreDetailsElement.replaceChildren();
+    (details || []).forEach(detail => {
+        const line = document.createElement('span');
+        line.textContent = detail;
+        scoreDetailsElement.appendChild(line);
+    });
+}
+
+function prettifyLabel(label) {
+    const normalized = String(label || '').toLowerCase();
+    return normalized.charAt(0).toUpperCase() + normalized.slice(1);
+}
+
+function interpretSentimentResponse(data) {
+    let predictions = data;
+    if (Array.isArray(predictions) && predictions.length === 1 && Array.isArray(predictions[0])) {
+        predictions = predictions[0];
+    }
+
+    if (!Array.isArray(predictions)) {
+        throw new Error('Unexpected response format from Hugging Face.');
+    }
+
+    const cleanedPredictions = predictions
+        .map(item => ({
+            label: typeof item.label === 'string' ? item.label.trim().toUpperCase() : '',
+            score: typeof item.score === 'number' ? item.score : NaN,
+        }))
+        .filter(item => item.label && Number.isFinite(item.score));
+
+    if (!cleanedPredictions.length) {
+        throw new Error('No sentiment predictions were returned.');
+    }
+
+    let positiveScore = null;
+    let negativeScore = null;
+    cleanedPredictions.forEach(item => {
+        if (item.label.includes('POSITIVE')) {
+            positiveScore = positiveScore === null ? item.score : Math.max(positiveScore, item.score);
+        }
+        if (item.label.includes('NEGATIVE')) {
+            negativeScore = negativeScore === null ? item.score : Math.max(negativeScore, item.score);
+        }
+    });
+
+    const detailLines = cleanedPredictions.map(item => `${prettifyLabel(item.label)}: ${(item.score * 100).toFixed(1)}%`);
+
+    if (positiveScore !== null && positiveScore > 0.5) {
+        return {
+            iconClasses: ['fa-solid', 'fa-thumbs-up'],
+            toneClass: 'positive',
+            labelText: 'Positive sentiment detected',
+            details: detailLines,
+        };
+    }
+
+    if (negativeScore !== null && negativeScore > 0.5) {
+        return {
+            iconClasses: ['fa-solid', 'fa-thumbs-down'],
+            toneClass: 'negative',
+            labelText: 'Negative sentiment detected',
+            details: detailLines,
+        };
+    }
+
+    return {
+        iconClasses: ['fa-solid', 'fa-circle-question'],
+        toneClass: 'neutral',
+        labelText: 'Neutral or uncertain sentiment',
+        details: detailLines,
+    };
+}
+
+async function queryHuggingFace(reviewText) {
+    const token = tokenInput.value.trim();
+    const headers = {
+        'Content-Type': 'application/json',
+    };
+
+    if (token) {
+        headers.Authorization = `Bearer ${token}`;
+    }
+
+    const response = await fetch('https://api-inference.huggingface.co/models/siebert/sentiment-roberta-large-english', {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ inputs: reviewText }),
+    });
+
+    const payload = await response.json().catch(() => {
+        throw new Error('Failed to parse the Hugging Face response.');
+    });
+
+    if (!response.ok) {
+        const errorMessage = typeof payload.error === 'string' ? payload.error : `HTTP ${response.status}`;
+        throw new Error(`Hugging Face API error: ${errorMessage}`);
+    }
+
+    if (payload.error) {
+        throw new Error(`Hugging Face API error: ${payload.error}`);
+    }
+
+    return payload;
+}
+
+function pickRandomReview() {
+    if (!reviewTexts.length) {
+        throw new Error('No reviews available to analyze.');
+    }
+    const index = Math.floor(Math.random() * reviewTexts.length);
+    return reviewTexts[index];
+}
+
+async function handleAnalyzeClick() {
+    if (isAnalyzing) {
+        return;
+    }
+    if (!reviewTexts.length) {
+        setStatus('Reviews are still loading or unavailable.');
+        return;
+    }
+
+    isAnalyzing = true;
+    analyzeButton.disabled = true;
+
+    const review = pickRandomReview();
+    reviewTextElement.textContent = review;
+    updateSentimentDisplay({
+        iconClasses: ['fa-solid', 'fa-circle-notch', 'fa-spin'],
+        toneClass: 'neutral',
+        labelText: 'Analyzing sentiment...',
+        details: [],
+    });
+    setStatus('Analyzing review with Hugging Face Inference API...');
+
+    try {
+        const response = await queryHuggingFace(review);
+        const sentimentData = interpretSentimentResponse(response);
+        updateSentimentDisplay(sentimentData);
+        setStatus('Analysis complete.');
+    } catch (error) {
+        console.error(error);
+        updateSentimentDisplay({
+            iconClasses: ['fa-solid', 'fa-triangle-exclamation'],
+            toneClass: 'negative',
+            labelText: 'Unable to determine sentiment',
+            details: [],
+        });
+        setStatus(error.message || 'An unknown error occurred while analyzing sentiment.');
+    } finally {
+        isAnalyzing = false;
+        analyzeButton.disabled = !reviewTexts.length;
+    }
+}
+
+async function loadReviews() {
+    try {
+        setStatus('Loading reviews from TSV file...');
+        reviewTextElement.textContent = 'Loading reviews...';
+        const response = await fetch('reviews_test.tsv', { cache: 'no-store' });
+        if (!response.ok) {
+            throw new Error(`Failed to fetch reviews (HTTP ${response.status}).`);
+        }
+        const tsvContent = await response.text();
+        const parsed = Papa.parse(tsvContent, {
+            header: true,
+            delimiter: '\t',
+            skipEmptyLines: true,
+        });
+
+        if (parsed.errors && parsed.errors.length) {
+            const firstError = parsed.errors[0];
+            throw new Error(`Parsing error on row ${firstError.row ?? 'unknown'}: ${firstError.message}`);
+        }
+
+        const texts = parsed.data
+            .map(row => (typeof row.text === 'string' ? row.text.trim() : ''))
+            .filter(text => text.length > 0);
+
+        if (!texts.length) {
+            throw new Error('No valid review texts found in the TSV file.');
+        }
+
+        reviewTexts = texts;
+        setReviewCount(reviewTexts.length);
+        analyzeButton.disabled = false;
+        reviewTextElement.textContent = 'Click "Analyze Random Review" to explore a sentiment insight!';
+        setStatus('Reviews loaded successfully.');
+    } catch (error) {
+        console.error(error);
+        reviewTexts = [];
+        analyzeButton.disabled = true;
+        setReviewCount(0);
+        reviewTextElement.textContent = 'Unable to load reviews.';
+        updateSentimentDisplay({
+            iconClasses: ['fa-solid', 'fa-circle-question'],
+            toneClass: 'neutral',
+            labelText: 'Sentiment analysis pending',
+            details: [],
+        });
+        setStatus(error.message || 'An unknown error occurred while loading reviews.');
+    }
+}
+
+analyzeButton.addEventListener('click', handleAnalyzeClick);
+loadReviews();

--- a/index.html
+++ b/index.html
@@ -1,1 +1,224 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Random Review Sentiment Explorer</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-p1CmS2+GIU2zFEgVJFP5rTnZLk2JdpLqQtIi6ntZjDUZIr05oig3NbS1V6jJQMBFjC3b8V3ucO8dvM8VxN8BGg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <style>
+        :root {
+            color-scheme: light dark;
+            --bg: #0f172a;
+            --card-bg: rgba(255, 255, 255, 0.08);
+            --accent: #38bdf8;
+            --text-primary: #f8fafc;
+            --text-secondary: #cbd5f5;
+        }
 
+        * {
+            box-sizing: border-box;
+        }
+
+        body {
+            margin: 0;
+            min-height: 100vh;
+            font-family: "Inter", "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+            background: linear-gradient(135deg, #0f172a, #1e293b);
+            color: var(--text-primary);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 2rem;
+        }
+
+        .app-shell {
+            width: min(900px, 100%);
+            background: linear-gradient(145deg, rgba(15, 23, 42, 0.95), rgba(30, 41, 59, 0.9));
+            border-radius: 18px;
+            padding: clamp(1.5rem, 4vw, 2.75rem);
+            box-shadow: 0 25px 60px rgba(15, 23, 42, 0.55);
+            backdrop-filter: blur(12px);
+            border: 1px solid rgba(148, 163, 184, 0.2);
+        }
+
+        header h1 {
+            margin: 0 0 0.5rem;
+            font-size: clamp(1.75rem, 5vw, 2.7rem);
+            font-weight: 700;
+            letter-spacing: 0.03em;
+        }
+
+        header p {
+            margin: 0;
+            font-size: clamp(1rem, 2.4vw, 1.15rem);
+            color: var(--text-secondary);
+            line-height: 1.6;
+        }
+
+        .input-row {
+            margin-top: 2rem;
+            display: grid;
+            gap: 0.75rem;
+        }
+
+        label {
+            font-weight: 600;
+            font-size: 0.95rem;
+            color: var(--text-secondary);
+        }
+
+        input[type="password"],
+        button {
+            font: inherit;
+            border-radius: 12px;
+            border: 1px solid rgba(148, 163, 184, 0.35);
+            padding: 0.85rem 1rem;
+            transition: all 0.2s ease;
+        }
+
+        input[type="password"] {
+            background: rgba(15, 23, 42, 0.6);
+            color: var(--text-primary);
+        }
+
+        input[type="password"]::placeholder {
+            color: rgba(148, 163, 184, 0.8);
+        }
+
+        button {
+            background: linear-gradient(135deg, #0ea5e9, #2563eb);
+            color: white;
+            font-weight: 600;
+            border: none;
+            cursor: pointer;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            gap: 0.6rem;
+            box-shadow: 0 15px 30px rgba(14, 165, 233, 0.25);
+        }
+
+        button:disabled {
+            opacity: 0.6;
+            cursor: not-allowed;
+            box-shadow: none;
+        }
+
+        button:not(:disabled):hover {
+            transform: translateY(-1px);
+            box-shadow: 0 22px 32px rgba(14, 165, 233, 0.35);
+        }
+
+        .review-card {
+            margin-top: 2.5rem;
+            background: var(--card-bg);
+            border-radius: 16px;
+            padding: clamp(1.25rem, 3vw, 2rem);
+            border: 1px solid rgba(148, 163, 184, 0.2);
+            display: grid;
+            gap: 1.5rem;
+        }
+
+        .review-text {
+            font-size: clamp(1rem, 2.6vw, 1.25rem);
+            line-height: 1.7;
+            color: #e2e8f0;
+            min-height: 4.5rem;
+        }
+
+        .status-message {
+            font-size: 0.95rem;
+            color: var(--text-secondary);
+            min-height: 1.2rem;
+        }
+
+        .result-row {
+            display: flex;
+            flex-wrap: wrap;
+            align-items: center;
+            justify-content: space-between;
+            gap: 1rem;
+        }
+
+        .sentiment-indicator {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.75rem;
+            font-size: 1rem;
+        }
+
+        .sentiment-icon {
+            font-size: clamp(2rem, 5vw, 2.6rem);
+            transition: transform 0.2s ease;
+        }
+
+        .sentiment-icon.positive {
+            color: #22c55e;
+        }
+
+        .sentiment-icon.negative {
+            color: #ef4444;
+        }
+
+        .sentiment-icon.neutral {
+            color: #eab308;
+        }
+
+        .scores {
+            display: grid;
+            gap: 0.25rem;
+            color: var(--text-secondary);
+            font-size: 0.9rem;
+        }
+
+        .review-count {
+            font-size: 0.9rem;
+            color: var(--text-secondary);
+        }
+
+        @media (max-width: 600px) {
+            body {
+                padding: 1rem;
+            }
+
+            .result-row {
+                flex-direction: column;
+                align-items: flex-start;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="app-shell">
+        <header>
+            <h1>Random Review Sentiment Explorer</h1>
+            <p>Load product reviews from a TSV file, grab a random entry, and instantly evaluate its sentiment using Hugging Face's <em>siebert/sentiment-roberta-large-english</em> model.</p>
+        </header>
+
+        <div class="input-row">
+            <label for="token-input">Hugging Face API Token <span style="font-weight: 400; color: rgba(148, 163, 184, 0.8);">(optional)</span></label>
+            <input id="token-input" type="password" placeholder="hf_... (leave blank for anonymous access)" autocomplete="off">
+            <button id="analyze-button" disabled>
+                <i class="fa-solid fa-shuffle"></i>
+                Analyze Random Review
+            </button>
+            <div class="review-count" id="review-count"></div>
+            <div class="status-message" id="status-message"></div>
+        </div>
+
+        <div class="review-card">
+            <div class="review-text" id="review-text">Loading reviews...</div>
+            <div class="result-row">
+                <div class="sentiment-indicator">
+                    <i class="fa-solid fa-circle-question sentiment-icon neutral" id="sentiment-icon" aria-hidden="true"></i>
+                    <span id="sentiment-label">Sentiment analysis pending</span>
+                </div>
+                <div class="scores" id="score-details"></div>
+            </div>
+        </div>
+    </div>
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/PapaParse/5.4.1/papaparse.min.js" integrity="sha512-3yjDvV6Xg3K05XdxQMUHppq74H5+1KX2wNT95HxW0QD9Y0ia6as4n9YTJ8HYJFDsUxw8yqXLg6BmOBLa9N4q3g==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="app.js"></script>
+</body>
+</html>

--- a/reviews_test.tsv
+++ b/reviews_test.tsv
@@ -1,0 +1,10 @@
+text
+This product exceeded my expectations and the build quality is outstanding.
+The item arrived broken and customer service never responded to my emails.
+It's okay overall, but there are better alternatives for the price.
+Absolutely love it! I would recommend this to everyone.
+The instructions were confusing and the accessories were missing.
+Solid value for the money and works exactly as described.
+Mediocre performance and the battery drains too quickly.
+Fantastic experience from ordering to delivery.
+Disappointed because it stopped working after just one week.


### PR DESCRIPTION
## Summary
- build a styled interface that supports Hugging Face token entry and displays random review sentiment feedback
- implement Papa Parse powered TSV loading and Hugging Face inference calls in a dedicated app.js module
- add a sample TSV dataset of product reviews for randomized analysis

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68caeaa5eea083208ff20524cedec331